### PR TITLE
Add OrganizationalUnit reference to OrganizationalUnit.ParentID

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:03:59Z"
-  build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
-  version: v0.60.0
-api_directory_checksum: e6d77bab071907a35ef7e1a082fcfe5dd568ddbc
+  build_date: "2026-06-25T23:01:05Z"
+  build_hash: 016cc97b328515c8db205ad1091916a0cc66614b
+  go_version: go1.26.0
+  version: v0.60.0-2-g016cc97
+api_directory_checksum: 866bfb77ab14e5814ca9baf346f695499954f765
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: c47cc75e49b494ba26c4ce81a8de3998f56025f8
+  file_checksum: c700fa607001ee211b1b5752e4da0c56718721a7
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -51,3 +51,7 @@ resources:
       ID:
         is_read_only: true
         is_primary_key: true
+      ParentID:
+        references:
+          resource: OrganizationalUnit
+          path: Status.ID

--- a/apis/v1alpha1/organizational_unit.go
+++ b/apis/v1alpha1/organizational_unit.go
@@ -48,8 +48,8 @@ type OrganizationalUnitSpec struct {
 	//     32 additional lowercase letters or digits.
 	//
 	// Regex Pattern: `^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$`
-	// +kubebuilder:validation:Required
-	ParentID *string `json:"parentID"`
+	ParentID  *string                                  `json:"parentID,omitempty"`
+	ParentRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"parentRef,omitempty"`
 	// A list of tags that you want to attach to the newly created OU. For each
 	// tag in the list, you must specify both a tag key and a value. You can set
 	// the value to an empty string, but you can't set it to null. For more information

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -530,6 +530,11 @@ func (in *OrganizationalUnitSpec) DeepCopyInto(out *OrganizationalUnitSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ParentRef != nil {
+		in, out := &in.ParentRef, &out.ParentRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]*Tag, len(*in))

--- a/config/crd/bases/organizations.services.k8s.aws_organizationalunits.yaml
+++ b/config/crd/bases/organizations.services.k8s.aws_organizationalunits.yaml
@@ -70,6 +70,23 @@ spec:
 
                   Regex Pattern: `^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$`
                 type: string
+              parentRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: |-
                   A list of tags that you want to attach to the newly created OU. For each
@@ -102,7 +119,6 @@ spec:
                 type: array
             required:
             - name
-            - parentID
             type: object
           status:
             description: OrganizationalUnitStatus defines the observed state of OrganizationalUnit

--- a/generator.yaml
+++ b/generator.yaml
@@ -51,3 +51,7 @@ resources:
       ID:
         is_read_only: true
         is_primary_key: true
+      ParentID:
+        references:
+          resource: OrganizationalUnit
+          path: Status.ID

--- a/helm/crds/organizations.services.k8s.aws_organizationalunits.yaml
+++ b/helm/crds/organizations.services.k8s.aws_organizationalunits.yaml
@@ -70,6 +70,23 @@ spec:
 
                   Regex Pattern: `^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$`
                 type: string
+              parentRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: |-
                   A list of tags that you want to attach to the newly created OU. For each
@@ -102,7 +119,6 @@ spec:
                 type: array
             required:
             - name
-            - parentID
             type: object
           status:
             description: OrganizationalUnitStatus defines the observed state of OrganizationalUnit

--- a/pkg/resource/organizational_unit/delta.go
+++ b/pkg/resource/organizational_unit/delta.go
@@ -20,6 +20,7 @@ import (
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // Hack to avoid import errors during build...
@@ -54,6 +55,9 @@ func newResourceDelta(
 		if *a.ko.Spec.ParentID != *b.ko.Spec.ParentID {
 			delta.Add("Spec.ParentID", a.ko.Spec.ParentID, b.ko.Spec.ParentID)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.ParentRef, b.ko.Spec.ParentRef) {
+		delta.Add("Spec.ParentRef", a.ko.Spec.ParentRef, b.ko.Spec.ParentRef)
 	}
 	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
 	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)

--- a/pkg/resource/organizational_unit/references.go
+++ b/pkg/resource/organizational_unit/references.go
@@ -17,9 +17,15 @@ package organizational_unit
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/organizations-controller/apis/v1alpha1"
@@ -31,6 +37,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.ParentRef != nil {
+		ko.Spec.ParentID = nil
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +57,119 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForParentID(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.OrganizationalUnit) error {
+
+	if ko.Spec.ParentRef != nil && ko.Spec.ParentID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ParentID", "ParentRef")
+	}
+	if ko.Spec.ParentRef == nil && ko.Spec.ParentID == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("ParentID", "ParentRef")
+	}
+	return nil
+}
+
+// resolveReferenceForParentID reads the resource referenced
+// from ParentRef field and sets the ParentID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForParentID(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.OrganizationalUnit,
+) (hasReferences bool, err error) {
+	if ko.Spec.ParentRef != nil && ko.Spec.ParentRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.ParentRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ParentRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.OrganizationalUnit{}
+		if err := getReferencedResourceState_OrganizationalUnit(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.ParentID = (*string)(obj.Status.ID)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_OrganizationalUnit looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_OrganizationalUnit(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.OrganizationalUnit,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"OrganizationalUnit",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"OrganizationalUnit",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"OrganizationalUnit",
+			namespace, name)
+	}
+	if obj.Status.ID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"OrganizationalUnit",
+			namespace, name,
+			"Status.ID")
+	}
 	return nil
 }


### PR DESCRIPTION
## Description
Add same-resource cross-reference from `OrganizationalUnit.ParentID` to `OrganizationalUnit`, identified by the ACK scanner gap analysis tool. This allows users to reference a parent ACK-managed OrganizationalUnit directly when building nested OU hierarchies.

### Changes
- `OrganizationalUnit.ParentID` → OrganizationalUnit (same controller)

### Testing
- Code generated with `make build-controller` (latest code-generator + runtime v0.60.0)
- Controller compiles: `go build -o bin/controller ./cmd/controller`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.